### PR TITLE
Add performance test for add image filter

### DIFF
--- a/examples/Filtering/BinaryAddBenchmark.cxx
+++ b/examples/Filtering/BinaryAddBenchmark.cxx
@@ -1,0 +1,105 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkImageFileReader.h"
+#include "itkImageFileWriter.h"
+#include "itkAddImageFilter.h"
+
+#include "itkHighPriorityRealTimeProbesCollector.h"
+#include "PerformanceBenchmarkingUtilities.h"
+#include <fstream>
+#include <cstdlib>
+
+namespace
+{
+template<typename TImageType>
+itk::SmartPointer<TImageType> ReadImage(const char *fname)
+{
+
+  using ReaderType = itk::ImageFileReader< TImageType >;
+  auto reader = ReaderType::New();
+  reader->SetFileName( fname );
+
+  try
+    {
+    reader->Update();
+    }
+  catch( itk::ExceptionObject & error )
+    {
+    std::cerr << "Error: " << error << std::endl;
+    std::exit(EXIT_FAILURE);
+    }
+  return reader->GetOutput();
+
+
+}
+}
+
+int main( int argc, char * argv[] )
+{
+  if( argc < 6 )
+    {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0] << " timingsFile iterations threads input1ImageFile input2ImageFile outputImageFile" << std::endl;
+    return EXIT_FAILURE;
+    }
+  const std::string timingsFileName = ReplaceOccurrence( argv[1], "__DATESTAMP__", PerfDateStamp());
+  const int iterations = atoi( argv[2] );
+  int threads = atoi( argv[3] );
+  const char * inputImage1FileName = argv[4];
+  const char * inputImage2FileName = argv[5];
+  const char * outputImageFileName = argv[6];
+
+  if( threads > 0 )
+    {
+    itk::MultiThreader::SetGlobalDefaultNumberOfThreads( threads );
+    }
+
+  constexpr unsigned int Dimension = 3;
+  using PixelType = float;
+
+  using ImageType = itk::Image< PixelType, 3 >;
+
+  ImageType::Pointer inputImage1 = ReadImage<ImageType>(inputImage1FileName);
+  ImageType::Pointer inputImage2 = ReadImage<ImageType>(inputImage2FileName);
+
+  using FilterType = itk::AddImageFilter< ImageType, ImageType, ImageType >;
+  FilterType::Pointer filter = FilterType::New();
+  filter->SetInput1( inputImage1 );
+  filter->SetInput2( inputImage2 );
+
+  itk::HighPriorityRealTimeProbesCollector collector;
+  for( int ii = 0; ii < iterations; ++ii )
+    {
+    inputImage1->Modified();
+    inputImage2->Modified();
+    collector.Start("Add");
+    filter->UpdateLargestPossibleRegion();
+    collector.Stop("Add");
+    }
+
+  WriteExpandedReport(timingsFileName, collector, true, true, false);
+
+  using WriterType = itk::ImageFileWriter< ImageType >;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName( outputImageFileName );
+  writer->SetInput( filter->GetOutput() );
+  writer->Update();
+
+  return EXIT_SUCCESS;
+}

--- a/examples/Filtering/CMakeLists.txt
+++ b/examples/Filtering/CMakeLists.txt
@@ -24,6 +24,35 @@ ExternalData_Add_Test(ITKBenchmarksData
   )
 set_property(TEST MedianBenchmark APPEND PROPERTY LABELS Filtering)
 
+add_executable(BinaryAddBenchmark BinaryAddBenchmark.cxx )
+target_link_libraries(BinaryAddBenchmark ${ITK_LIBRARIES})
+ExternalData_Add_Test(ITKBenchmarksData
+  NAME BinaryAddBenchmark
+  COMMAND BinaryAddBenchmark
+    ${TEST_OUTPUT_DIR}/BinaryAddBenchmark__DATESTAMP__.json
+    50
+    1
+    ${BRAIN_IMAGE}
+    ${BRAIN_IMAGE}
+    ${TEST_OUTPUT_DIR}/BinaryAddBenchmark.mha
+  )
+set_property(TEST BinaryAddBenchmark APPEND PROPERTY LABELS Filtering)
+
+add_executable(UnaryAddBenchmark UnaryAddBenchmark.cxx )
+target_link_libraries(UnaryAddBenchmark ${ITK_LIBRARIES})
+ExternalData_Add_Test(ITKBenchmarksData
+  NAME UnaryAddBenchmark
+  COMMAND UnaryAddBenchmark
+    ${TEST_OUTPUT_DIR}/UnaryAddBenchmark__DATESTAMP__.json
+    50
+    1
+    ${BRAIN_IMAGE}
+    ${BRAIN_IMAGE}
+    ${TEST_OUTPUT_DIR}/UnaryAddBenchmark.mha
+  )
+set_property(TEST UnaryAddBenchmark APPEND PROPERTY LABELS Filtering)
+
+
 add_executable(GradientMagnitudeBenchmark GradientMagnitudeBenchmark.cxx )
 target_link_libraries(GradientMagnitudeBenchmark ${ITK_LIBRARIES})
 ExternalData_Add_Test(ITKBenchmarksData
@@ -62,4 +91,4 @@ ExternalData_Add_Test(ITKBenchmarksData
 set_property(TEST MinMaxCurvatureFlowBenchmark APPEND PROPERTY LABELS Filtering)
 
 ## performance tests should not be run in parallel
-set_tests_properties(MedianBenchmark GradientMagnitudeBenchmark MinMaxCurvatureFlowBenchmark PROPERTIES RUN_SERIAL TRUE)
+set_tests_properties(MedianBenchmark BinaryAddBenchmark UnaryAddBenchmark GradientMagnitudeBenchmark MinMaxCurvatureFlowBenchmark PROPERTIES RUN_SERIAL TRUE)

--- a/examples/Filtering/UnaryAddBenchmark.cxx
+++ b/examples/Filtering/UnaryAddBenchmark.cxx
@@ -1,0 +1,102 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkImageFileReader.h"
+#include "itkImageFileWriter.h"
+#include "itkAddImageFilter.h"
+
+#include "itkHighPriorityRealTimeProbesCollector.h"
+#include "PerformanceBenchmarkingUtilities.h"
+#include <fstream>
+#include <cstdlib>
+
+namespace
+{
+template<typename TImageType>
+itk::SmartPointer<TImageType> ReadImage(const char *fname)
+{
+
+  using ReaderType = itk::ImageFileReader< TImageType >;
+  auto reader = ReaderType::New();
+  reader->SetFileName( fname );
+
+  try
+    {
+    reader->Update();
+    }
+  catch( itk::ExceptionObject & error )
+    {
+    std::cerr << "Error: " << error << std::endl;
+    std::exit(EXIT_FAILURE);
+    }
+  return reader->GetOutput();
+
+
+}
+}
+
+int main( int argc, char * argv[] )
+{
+  if( argc < 6 )
+    {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0] << " timingsFile iterations threads input1ImageFile outputImageFile" << std::endl;
+    return EXIT_FAILURE;
+    }
+  const std::string timingsFileName = ReplaceOccurrence( argv[1], "__DATESTAMP__", PerfDateStamp());
+  const int iterations = atoi( argv[2] );
+  int threads = atoi( argv[3] );
+  const char * inputImage1FileName = argv[4];
+  const char * outputImageFileName = argv[5];
+
+  if( threads > 0 )
+    {
+    itk::MultiThreader::SetGlobalDefaultNumberOfThreads( threads );
+    }
+
+  constexpr unsigned int Dimension = 3;
+  using PixelType = float;
+
+  using ImageType = itk::Image< PixelType, 3 >;
+
+  ImageType::Pointer inputImage1 = ReadImage<ImageType>(inputImage1FileName);
+
+  using FilterType = itk::AddImageFilter< ImageType, ImageType, ImageType >;
+  FilterType::Pointer filter = FilterType::New();
+  filter->SetInput1( inputImage1 );
+  filter->SetInput2( 10 );
+
+  itk::HighPriorityRealTimeProbesCollector collector;
+  for( int ii = 0; ii < iterations; ++ii )
+    {
+    inputImage1->Modified();
+    collector.Start("Add");
+    filter->UpdateLargestPossibleRegion();
+    collector.Stop("Add");
+    }
+
+  WriteExpandedReport(timingsFileName, collector, true, true, false);
+
+  using WriterType = itk::ImageFileWriter< ImageType >;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName( outputImageFileName );
+  writer->SetInput( filter->GetOutput() );
+  writer->Update();
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
The current implementation of the filter uses the
BinaryFunctorImageFilter. The purpose of this test is to verify there
is not performance regression with the proposed "Generator" base add
image filter.