### PR TITLE
STYLE: Prefer error checked std::sto[id] over ato[if].

### DIFF
--- a/examples/Core/ThreadOverhead.cxx
+++ b/examples/Core/ThreadOverhead.cxx
@@ -127,8 +127,8 @@ int main( int argc, char * argv[] )
     }
 
   const std::string timingsFileName = ReplaceOccurrence( argv[1], "__DATESTAMP__", PerfDateStamp());
-  const int iterations = (argc>2) ? atoi( argv[2] ): 500;
-  const int threads = (argc>3) ? atoi( argv[3] ) : MultiThreaderName::GetGlobalDefaultNumberOfThreads();
+  const int iterations = (argc>2) ? std::stoi( argv[2] ): 500;
+  const int threads = (argc>3) ? std::stoi( argv[3] ) : MultiThreaderName::GetGlobalDefaultNumberOfThreads();
 
   if (threads == 1)
     {

--- a/examples/Filtering/BinaryAddBenchmark.cxx
+++ b/examples/Filtering/BinaryAddBenchmark.cxx
@@ -59,8 +59,8 @@ int main( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
   const std::string timingsFileName = ReplaceOccurrence( argv[1], "__DATESTAMP__", PerfDateStamp());
-  const int iterations = atoi( argv[2] );
-  int threads = atoi( argv[3] );
+  const int iterations = std::stoi( argv[2] );
+  int threads = std::stoi( argv[3] );
   const char * inputImage1FileName = argv[4];
   const char * inputImage2FileName = argv[5];
   const char * outputImageFileName = argv[6];

--- a/examples/Filtering/GradientMagnitudeBenchmark.cxx
+++ b/examples/Filtering/GradientMagnitudeBenchmark.cxx
@@ -33,8 +33,8 @@ int main( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
   const std::string timingsFileName = ReplaceOccurrence( argv[1], "__DATESTAMP__", PerfDateStamp());
-  const int iterations = atoi( argv[2] );
-  int threads = atoi( argv[3] );
+  const int iterations = std::stoi( argv[2] );
+  int threads = std::stoi( argv[3] );
   const char * inputImageFileName = argv[4];
   const char * outputImageFileName = argv[5];
 

--- a/examples/Filtering/MedianBenchmark.cxx
+++ b/examples/Filtering/MedianBenchmark.cxx
@@ -33,8 +33,8 @@ int main( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
   const std::string timingsFileName = ReplaceOccurrence( argv[1], "__DATESTAMP__", PerfDateStamp());
-  const int iterations = atoi( argv[2] );
-  int threads = atoi( argv[3] );
+  const int iterations = std::stoi( argv[2] );
+  int threads = std::stoi( argv[3] );
   const char * inputImageFileName = argv[4];
   const char * outputImageFileName = argv[5];
 

--- a/examples/Filtering/MinMaxCurvatureFlowBenchmark.cxx
+++ b/examples/Filtering/MinMaxCurvatureFlowBenchmark.cxx
@@ -33,8 +33,8 @@ int main( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
   const std::string timingsFileName = ReplaceOccurrence( argv[1], "__DATESTAMP__", PerfDateStamp());
-  const int iterations = atoi( argv[2] );
-  int threads = atoi( argv[3] );
+  const int iterations = std::stoi( argv[2] );
+  int threads = std::stoi( argv[3] );
   const char * inputImageFileName = argv[4];
   const char * outputImageFileName = argv[5];
 

--- a/examples/Filtering/UnaryAddBenchmark.cxx
+++ b/examples/Filtering/UnaryAddBenchmark.cxx
@@ -59,8 +59,8 @@ int main( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
   const std::string timingsFileName = ReplaceOccurrence( argv[1], "__DATESTAMP__", PerfDateStamp());
-  const int iterations = atoi( argv[2] );
-  int threads = atoi( argv[3] );
+  const int iterations = std::stoi( argv[2] );
+  int threads = std::stoi( argv[3] );
   const char * inputImage1FileName = argv[4];
   const char * outputImageFileName = argv[5];
 

--- a/examples/Registration/DemonsRegistrationBenchmark.cxx
+++ b/examples/Registration/DemonsRegistrationBenchmark.cxx
@@ -73,8 +73,8 @@ int main( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
   const std::string timingsFileName = ReplaceOccurrence( argv[1], "__DATESTAMP__", PerfDateStamp());
-  const int iterations = atoi( argv[2] );
-  int threads = atoi( argv[3] );
+  const int iterations = std::stoi( argv[2] );
+  int threads = std::stoi( argv[3] );
   const char * fixedImageFileName = argv[4];
   const char * movingImageFileName = argv[5];
   const char * outputFileName = argv[6];

--- a/examples/Registration/NormalizedCorrelationBenchmark.cxx
+++ b/examples/Registration/NormalizedCorrelationBenchmark.cxx
@@ -33,8 +33,8 @@ int main(int argc, char * argv[])
     return EXIT_FAILURE;
     }
   const std::string timingsFileName = ReplaceOccurrence( argv[1], "__DATESTAMP__", PerfDateStamp());
-  const int iterations = atoi( argv[2] );
-  int threads = atoi( argv[3] );
+  const int iterations = std::stoi( argv[2] );
+  int threads = std::stoi( argv[3] );
   const std::string fixedImageFileName = argv[4];
   const std::string movingImageFileName = argv[5];
 

--- a/examples/Registration/RegistrationFrameworkBenchmark.cxx
+++ b/examples/Registration/RegistrationFrameworkBenchmark.cxx
@@ -72,8 +72,8 @@ int main( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
   const std::string timingsFileName = ReplaceOccurrence( argv[1], "__DATESTAMP__", PerfDateStamp());
-  const int iterations = atoi( argv[2] );
-  int threads = atoi( argv[3] );
+  const int iterations = std::stoi( argv[2] );
+  int threads = std::stoi( argv[3] );
   const char * fixedImageFileName = argv[4];
   const char * movingImageFileName = argv[5];
   const char * outputTransformFileName = argv[6];

--- a/examples/Segmentation/LevelSetBenchmark.cxx
+++ b/examples/Segmentation/LevelSetBenchmark.cxx
@@ -40,8 +40,8 @@ int main( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
   const std::string timingsFileName = ReplaceOccurrence( argv[1], "__DATESTAMP__", PerfDateStamp());
-  const int iterations = atoi( argv[2] );
-  int threads = atoi( argv[3] );
+  const int iterations = std::stoi( argv[2] );
+  int threads = std::stoi( argv[3] );
   const char * inputImageFileName = argv[4];
   const char * outputImageFileName = argv[5];
 

--- a/examples/Segmentation/MorphologicalWatershedBenchmark.cxx
+++ b/examples/Segmentation/MorphologicalWatershedBenchmark.cxx
@@ -38,7 +38,7 @@ int main( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
   const std::string timingsFileName = ReplaceOccurrence( argv[1], "__DATESTAMP__", PerfDateStamp());
-  const int iterations = atoi( argv[2] );
+  const int iterations = std::stoi( argv[2] );
   const char * inputImageFileName = argv[3];
   const char * outputImageFileName = argv[4];
 

--- a/examples/Segmentation/RegionGrowingBenchmark.cxx
+++ b/examples/Segmentation/RegionGrowingBenchmark.cxx
@@ -37,8 +37,8 @@ int main( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
   const std::string timingsFileName = ReplaceOccurrence( argv[1], "__DATESTAMP__", PerfDateStamp());
-  const int iterations = atoi( argv[2] );
-  int threads = atoi( argv[3] );
+  const int iterations = std::stoi( argv[2] );
+  int threads = std::stoi( argv[3] );
   const char * inputImageFileName = argv[4];
   const char * outputImageFileName = argv[5];
 

--- a/examples/Segmentation/WatershedBenchmark.cxx
+++ b/examples/Segmentation/WatershedBenchmark.cxx
@@ -38,8 +38,8 @@ int main( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
   const std::string timingsFileName = ReplaceOccurrence( argv[1], "__DATESTAMP__", PerfDateStamp());
-  const int iterations = atoi( argv[2] );
-  int threads = atoi( argv[3] );
+  const int iterations = std::stoi( argv[2] );
+  int threads = std::stoi( argv[3] );
   const char * inputImageFileName = argv[4];
   const char * outputImageFileName = argv[5];
 


### PR DESCRIPTION
The `ato[if]` functions do not provide mechanisms for distinguishing
between `0` and the error condition where the input can not be converted.

`std::sto[id]` provides exception handling and detects when an invalid
string attempts to be converted to an [integer|double].

`ato[if]()`
 - **Con**: No error handling.
 - **Con**: Handle neither hexadecimal nor octal.

The use of `ato[if]` in code can cause it to be subtly broken.
`ato[if]` makes two very big assumptions indeed:
 - The string represents an integer/floating point value.
 - The integer can fit into an int.

In agreement with:
http://review.source.kitware.com/#/c/23738/