### PR TITLE
ENH: Replace --no-merges with --first-parent for comment

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -14,4 +14,4 @@ on:
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.5
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.6

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,14 @@ if(NOT ITK_SOURCE_DIR)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
   endif()
 
+project(PerformanceBenchmarking)
+
+option(ITK_USES_NUMBEROFTHREADS "If ITKv5 uses NumberOfThreads (not NumberOfWorkUnits" OFF)
+
+set(PerformanceBenchmarking_LIBRARIES PerformanceBenchmarking)
+
+include_directories(${CMAKE_BINARY_DIR})
+if(NOT ITK_SOURCE_DIR)
   include(ITKModuleExternal)
 else()
   set(ITK_DIR ${CMAKE_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,12 +48,9 @@ if(NOT ITK_SOURCE_DIR)
     # Set the possible values of build type for cmake-gui
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
   endif()
+endif()
 
-project(PerformanceBenchmarking)
-
-option(ITK_USES_NUMBEROFTHREADS "If ITKv5 uses NumberOfThreads (not NumberOfWorkUnits" OFF)
-
-set(PerformanceBenchmarking_LIBRARIES PerformanceBenchmarking)
+option(ITK_USES_NUMBEROFTHREADS "If ITKv5 uses NumberOfThreads (not NumberOfWorkUnits)" OFF)
 
 include_directories(${CMAKE_BINARY_DIR})
 if(NOT ITK_SOURCE_DIR)

--- a/evaluate-itk-performance.py
+++ b/evaluate-itk-performance.py
@@ -40,7 +40,7 @@ run_parser.add_argument('bin', help='ITK build directory', action = FullPaths)
 run_parser.add_argument('benchmark_bin',
         help='ITK performance benchmarks build directory', action = FullPaths)
 run_parser.add_argument('-r', '--rev-list',
-        help='Arguments for "git rev-list" to select the range of commits to benchmark, for example: "--no-merges v4.10.0..v5.0rc1"',
+        help='Arguments for "git rev-list" to select the range of commits to benchmark, for example: "--first-parent v4.10.0..v5.0rc1"',
         default='--no-merges HEAD~1..')
 
 upload_parser = subparsers.add_parser('upload',

--- a/evaluate-itk-performance.py
+++ b/evaluate-itk-performance.py
@@ -7,6 +7,8 @@ import os
 import socket
 import json
 
+import glob
+
 
 def get_shell_output_as_string(commandlist):
     """
@@ -309,6 +311,18 @@ if args.command == 'run':
         os.environ['ITKPERFORMANCEBENCHMARK_AUX_JSON'] = \
             json.dumps(itk_information)
 
+        ## Remove vcl_compiler.h in build dir that takes precidence over older non-generated
+        ## vcl_compiler.h in the source tree (older source code).
+        if not os.path.exists( os.path.join( args.src, 'Modules','ThirdParty','VNL','src','vxl','vcl','vcl_compiler.h.in') ):
+             generated_vcl_headers = glob.glob(os.path.join( args.bin, 'Modules','ThirdParty','VNL','src','vxl','vcl',"*.h"))
+             for vcl_header_file in generated_vcl_headers:
+                 os.remove( vcl_header_file )
+
+        ## HDF generates and tries to build .c files from other builds, clean these out
+        hdf5_generated_files = os.path.join( args.bin, 'Modules','ThirdParty','HDF5','src','itkhdf5',"*.c")
+        hdf5_bld_src_files = glob.glob( hdf5_generated_files )
+        for hdf5_file in hdf5_bld_src_files:
+             os.remove( hdf5_file )
 
         print('\nBuilding ITK...')
         build_itk(args.src, args.bin)

--- a/include/PerformanceBenchmarkingUtilities.h
+++ b/include/PerformanceBenchmarkingUtilities.h
@@ -5,20 +5,20 @@
 #ifndef PerformanceBenchmarkingUtilities_h
 #define PerformanceBenchmarkingUtilities_h
 
-#include "PerformanceBenchmarkingExport.h"
+#include "PerformanceBenchmarkingInformation.h"
 
 #include "jsonxx.h"
 #include <ctime> //TODO:  Move to utiliites
 #include "itkHighPriorityRealTimeProbesCollector.h"
 
-#if ITK_VERSION_MAJOR >= 5
-#  include "itkMultiThreaderBase.h"
-using MultiThreaderName = itk::MultiThreaderBase;
-#  define SET_PARALLEL_UNITS(x) SetNumberOfWorkUnits(x)
-#else
-#  include "itkMultiThreader.h"
+#if ITK_VERSION_MAJOR < 5 || defined(ITK_USES_NUMBEROFTHREADS)
+#include "itkMultiThreader.h"
 using MultiThreaderName = itk::MultiThreader;
-#  define SET_PARALLEL_UNITS(x) SetNumberOfThreads(x)
+#define SET_PARALLEL_UNITS( x ) SetNumberOfThreads( x )
+#else
+#include "itkMultiThreaderBase.h"
+using MultiThreaderName = itk::MultiThreaderBase;
+#define SET_PARALLEL_UNITS( x ) SetNumberOfWorkUnits( x )
 #endif
 
 PerformanceBenchmarking_EXPORT std::string

--- a/include/PerformanceBenchmarkingUtilities.h
+++ b/include/PerformanceBenchmarkingUtilities.h
@@ -12,17 +12,17 @@
 #include "itkHighPriorityRealTimeProbesCollector.h"
 
 #if ITK_VERSION_MAJOR < 5 || defined(ITK_USES_NUMBEROFTHREADS)
-#include "itkMultiThreader.h"
+#  include "itkMultiThreader.h"
 using MultiThreaderName = itk::MultiThreader;
-#define SET_PARALLEL_UNITS( x ) SetNumberOfThreads( x )
+#  define SET_PARALLEL_UNITS(x) SetNumberOfThreads(x)
 #else
-#include "itkMultiThreaderBase.h"
+#  include "itkMultiThreaderBase.h"
 using MultiThreaderName = itk::MultiThreaderBase;
-#define SET_PARALLEL_UNITS( x ) SetNumberOfWorkUnits( x )
+#  define SET_PARALLEL_UNITS(x) SetNumberOfWorkUnits(x)
 #endif
 
 PerformanceBenchmarking_EXPORT std::string
-                               PerfDateStamp();
+PerfDateStamp();
 
 PerformanceBenchmarking_EXPORT std::string
 ReplaceOccurrence(std::string str, const std::string && findvalue, const std::string && replacevalue);

--- a/include/PerformanceBenchmarkingUtilities.h
+++ b/include/PerformanceBenchmarkingUtilities.h
@@ -22,7 +22,7 @@ using MultiThreaderName = itk::MultiThreaderBase;
 #endif
 
 PerformanceBenchmarking_EXPORT std::string
-PerfDateStamp();
+                               PerfDateStamp();
 
 PerformanceBenchmarking_EXPORT std::string
 ReplaceOccurrence(std::string str, const std::string && findvalue, const std::string && replacevalue);

--- a/src/PerformanceBenchmarkingInformation.h.in
+++ b/src/PerformanceBenchmarkingInformation.h.in
@@ -30,6 +30,8 @@
 
 #include "PerformanceBenchmarkingExport.h"
 
+#cmakedefine ITK_USES_NUMBEROFTHREADS
+
 
 namespace itk
 {

--- a/src/PerformanceBenchmarkingInformation.h.in
+++ b/src/PerformanceBenchmarkingInformation.h.in
@@ -51,13 +51,13 @@ namespace itk
  * \ingroup PerformanceBenchmarking
  *
  */
-class PerformanceBenchmarking_EXPORT PerformanceBenchmarkingInformation final: public itk::Object
+class PerformanceBenchmarking_EXPORT PerformanceBenchmarkingInformation final : public itk::Object
 {
 public:
   /** Standard class type aliases. */
   using Self = PerformanceBenchmarkingInformation;
-  using Pointer = itk::SmartPointer< Self >;
-  using ConstPointer = itk::SmartPointer< const Self >;
+  using Pointer = itk::SmartPointer<Self>;
+  using ConstPointer = itk::SmartPointer<const Self>;
   using MapKeyType = std::string;
   using MapValueType = std::string;
   using MapValueDescriptionType = MapValueType;
@@ -72,29 +72,35 @@ private:
   {
   public:
     InformationValueType() = default;
-    InformationValueType( const InformationValueType & ) = default;
-    InformationValueType( InformationValueType && ) = default;
+    InformationValueType(const InformationValueType &) = default;
+    InformationValueType(InformationValueType &&) = default;
 
     const MapValueType            m_Value;
     const MapValueDescriptionType m_Description;
   };
-public:
 
+public:
   using MapStorageType = InformationValueType;
-  using MapType = std::map<MapKeyType, MapStorageType >;
+  using MapType = std::map<MapKeyType, MapStorageType>;
 
   /** Run-time type information (and related methods). */
   itkOverrideGetNameOfClassMacro(PerformanceBenchmarkingInformation);
 
   /** Returns the global instance */
-  static Pointer New();
+  static Pointer
+  New();
 
   /** Returns the global singleton instance of the PerformanceBenchmarkingInformation */
-  static Pointer GetInstance();
-  static const MapType & GetMap();
-  static const MapValueType GetValue(const MapKeyType &&);
-  static const MapValueDescriptionType  GetDescription(const MapKeyType &&);
-  static const std::vector< MapKeyType > GetAllKeys();
+  static Pointer
+  GetInstance();
+  static const MapType &
+  GetMap();
+  static const MapValueType
+  GetValue(const MapKeyType &&);
+  static const MapValueDescriptionType
+  GetDescription(const MapKeyType &&);
+  static const std::vector<MapKeyType>
+  GetAllKeys();
 
 private:
   ITK_DISALLOW_COPY_AND_MOVE(PerformanceBenchmarkingInformation);
@@ -105,7 +111,7 @@ private:
   static std::mutex m_Mutex;
   static Pointer    m_InformationInstance;
   static MapType    m_Map;
-};  // end of class
+}; // end of class
 
 } // end namespace itk
 #endif


### PR DESCRIPTION
When walking through the git histories, we want the parent versions
of the previous commits rather than the --no-merges.  The --no-merges
results in failures for the merges that include (vnl, hdf5, or other
Thirdparty updates).