### PR TITLE
COMP: Remove unused variable warning

### DIFF
--- a/examples/Registration/DemonsRegistrationBenchmark.cxx
+++ b/examples/Registration/DemonsRegistrationBenchmark.cxx
@@ -88,7 +88,6 @@ main(int argc, char * argv[])
 
   constexpr unsigned int Dimension = 3;
   using PixelType = float;
-  using ParametersValueType = double;
 
   using ImageType = itk::Image<PixelType, Dimension>;
 

--- a/examples/Registration/NormalizedCorrelationBenchmark.cxx
+++ b/examples/Registration/NormalizedCorrelationBenchmark.cxx
@@ -46,7 +46,6 @@ main(int argc, char * argv[])
 
   constexpr unsigned int Dimension = 3;
   using PixelType = float;
-  using ParametersValueType = double;
 
   using ImageType = itk::Image<PixelType, Dimension>;
 


### PR DESCRIPTION
This removes an unused variable warning thrown. Removing `ParametersValueType` solves this as it is not used anywhere.