### PR TITLE
ENH: Bump ITK to latest commit in `master`

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "d6b1224bc3724cbaad190fda77e99a6a2529d29d"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "d6b1224bc3724cbaad190fda77e99a6a2529d29d"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "d6b1224bc3724cbaad190fda77e99a6a2529d29d"
             cmake-build-type: "MinSizeRel"
 
     steps:


### PR DESCRIPTION
Bump ITK to latest commit in `master`.

Fixes:
```
[1845/2161] Building C object Modules\ThirdParty\OpenJPEG\src\openjpeg\CMakeFiles\itkopenjpeg.dir\event.c.obj

FAILED: Modules/ThirdParty/OpenJPEG/src/openjpeg/CMakeFiles/itkopenjpeg.dir/event.c.obj

D:\a\ITKPerformanceBenchmarking\ITK\Modules\ThirdParty\OpenJPEG\src\openjpeg\opj_includes.h(106):
error C2169: 'lrintf': intrinsic function, cannot be defined
```

reported in
https://github.com/InsightSoftwareConsortium/ITKPerformanceBenchmarking/pull/90/checks?check_run_id=3571426392#step:8:2707