### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/LOCAL_itkResourceProbe.hxx
+++ b/include/LOCAL_itkResourceProbe.hxx
@@ -36,7 +36,6 @@
 #include <utility>
 #include <type_traits>
 
-#include "LOCAL_itkResourceProbe.h"
 #include "itkNumericTraits.h"
 #include "itksys/SystemInformation.hxx"
 #include "itkMath.h"

--- a/include/LOCAL_itkResourceProbesCollectorBase.hxx
+++ b/include/LOCAL_itkResourceProbesCollectorBase.hxx
@@ -18,7 +18,6 @@
 #ifndef itkLOCALResourceProbesCollectorBase_hxx
 #define itkLOCALResourceProbesCollectorBase_hxx
 
-#include "LOCAL_itkResourceProbesCollectorBase.h"
 #include <iostream>
 
 namespace itk


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

