### PR TITLE
ENH: Modernize CMake configuration for examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ project(PerformanceBenchmarking
 )
 
 set(PerformanceBenchmarking_LIBRARIES PerformanceBenchmarking)
+# Path for configured PerformanceBenchmarkingInformation.h
+set(PerformanceBenchmarking_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/include/)
+
+set(Module_PerformanceBenchmarking_BUILD_EXAMPLES ON)
 
 if(NOT ITK_SOURCE_DIR)
   find_package(ITK REQUIRED)
@@ -51,5 +55,4 @@ else()
   itk_module_impl()
 endif()
 
-itk_module_examples() # This builds the src directory
-add_subdirectory(examples) # this builds each of the itk benchmark domains
+itk_module_examples() # This builds the examples directory

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,7 @@ set(MAPPING_VALUES "
 configure_file(PerformanceBenchmarkingInformation.cxx.in ${CMAKE_BINARY_DIR}/PerformanceBenchmarkingInformation.cxx)
 configure_file(PerformanceBenchmarkingInformation.h.in ${CMAKE_BINARY_DIR}/include/PerformanceBenchmarkingInformation.h)
 
+
 set( PerformanceBenchmarking_SRCS
     jsonxx.cc ## MIT License https://github.com/hjiang/jsonxx
     ${CMAKE_BINARY_DIR}/PerformanceBenchmarkingInformation.cxx


### PR DESCRIPTION
- Fixes compilation issue when enabling in an ITK build with Examples turned on.
- Explicitly enable BUILD_EXAMPLES by setting `Module_PerformanceBenchmarking_BUILD_EXAMPLES ON`
- Set `PerformanceBenchmarking_INCLUDE_DIRS` for configured header accessibility
- Remove duplicate examples subdirectory addition (`itk_module_examples()` handles it)