### PR TITLE
COMP: Use ITK default branch origin/main in ASV config and docs

### DIFF
--- a/README-asv.md
+++ b/README-asv.md
@@ -69,7 +69,7 @@ asv run --machine $(hostname -s) --set-commit-hash "$ITK_SHA" --python=same
 ```sh
 # Assumes ITK-base-build and ITK-head-build already exist, and the
 # itk-repo symlink points at the ITK clone.
-BASE_SHA=$(cd itk-repo && git merge-base origin/master HEAD)
+BASE_SHA=$(cd itk-repo && git merge-base origin/main HEAD)
 HEAD_SHA=$(cd itk-repo && git rev-parse HEAD)
 
 ITK_BENCHMARK_BIN=/path/to/ITK-base-build/bin \

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -4,7 +4,7 @@
     "project_url": "https://itk.org/",
     "_comment_repo": "'repo' points at the ITK source tree whose commits label the time series. The caller (CI workflow or local smoke test) must create a symlink named 'itk-repo' at the root of this harness pointing to the ITK clone before invoking asv.",
     "repo": "itk-repo",
-    "branches": ["origin/master"],
+    "branches": ["origin/main"],
     "environment_type": "existing",
     "show_commit_url": "https://github.com/InsightSoftwareConsortium/ITK/commit/",
     "benchmark_dir": "benchmarks",


### PR DESCRIPTION
ITK's default branch renamed to `main` some time ago; the ASV harness still referenced `origin/master`, causing `asv run` to abort with `Unknown branch origin/master in configuration` whenever the caller's `itk-repo` symlink points at a modern ITK checkout.  Switches the two in-repo references (`asv.conf.json` + `README-asv.md`).

<details>
<summary>Failure signal that motivated this</summary>

Observed on InsightSoftwareConsortium/ITK#612 (ENH: Add performance benchmark CI builds), which runs this harness against `origin/main` ITK:

```
· Unknown branch origin/master in configuration
##[error]Process completed with exit code 1.
```

The ITK-side workflow currently carries a sed-patch workaround at harness-stage time; once this PR merges and #612's pin is bumped, that workaround can be deleted.

</details>

<details>
<summary>Scope</summary>

- `asv.conf.json:7` — `branches: ["origin/master"]` → `["origin/main"]`
- `README-asv.md:72` — PR-comparison example now uses `git merge-base origin/main HEAD`

No functional change to the benchmark code or harness logic; the fix is purely to the branch identifier ASV uses to label the time series it writes to `.asv/results/`.

</details>

<details>
<summary>Note on this repo's own default branch</summary>

`InsightSoftwareConsortium/ITKPerformanceBenchmarking` itself still uses `master` as its default branch (per `git remote show origin`); the `branches` config here labels commits in the *ITK* checkout that `itk-repo` points at, not this repo's own branches.  Renaming this repo's default branch is out of scope.

</details>

<!--
provenance: claude-code session 2026-04-23
itk_pr_referenced: InsightSoftwareConsortium/ITK#612
key_facts:
  - scope: 2-line diff in 2 files (asv.conf.json, README-asv.md)
  - functional_change: none; ASV branch label only
  - motivator_pr: InsightSoftwareConsortium/ITK#612 (thewtex)
post_merge_action: bump Modules/Remote/PerformanceBenchmarking.remote.cmake GIT_TAG in ITK#612 and drop the in-workflow sed patch
-->