### PR TITLE
COMP: Drop unused InputPixelType typedefs in CopyIterationBenchmark

### DIFF
--- a/examples/Core/itkCopyIterationBenchmark.cxx
+++ b/examples/Core/itkCopyIterationBenchmark.cxx
@@ -116,7 +116,6 @@ template <typename TInputImage, typename TOutputImage>
 void
 CopyRegionIterator(const TInputImage * inputPtr, TOutputImage * outputPtr)
 {
-  using InputPixelType = typename TInputImage::PixelType;
   using OutputPixelType = typename TOutputImage::PixelType;
   using ImageRegionConstIterator = itk::ImageRegionConstIterator<TInputImage>;
   using ImageRegionIterator = itk::ImageRegionIterator<TOutputImage>;
@@ -139,7 +138,6 @@ template <typename TInputImage, typename TOutputImage>
 void
 CopyScanlineIterator(const TInputImage * inputPtr, TOutputImage * outputPtr)
 {
-  using InputPixelType = typename TInputImage::PixelType;
   using OutputPixelType = typename TOutputImage::PixelType;
   using ImageScanlineConstIterator = itk::ImageScanlineConstIterator<TInputImage>;
   using ImageScanlineIterator = itk::ImageScanlineIterator<TOutputImage>;


### PR DESCRIPTION
Remove two unused `using InputPixelType = ...;` local typedefs in `examples/Core/itkCopyIterationBenchmark.cxx` to silence `-Wunused-local-typedefs` warnings.

<details>
<summary>Warning text</summary>

```
examples/Core/itkCopyIterationBenchmark.cxx:119:9: warning: typedef 'using InputPixelType = typename TInputImage::PixelType' locally defined but not used [-Wunused-local-typedefs]
  119 |   using InputPixelType = typename TInputImage::PixelType;
      |         ^~~~~~~~~~~~~~
examples/Core/itkCopyIterationBenchmark.cxx:142:9: warning: typedef 'using InputPixelType = typename TInputImage::PixelType' locally defined but not used [-Wunused-local-typedefs]
  142 |   using InputPixelType = typename TInputImage::PixelType;
      |         ^~~~~~~~~~~~~~
```

</details>

<details>
<summary>Why these two only</summary>

`CopyRegionIterator` and `CopyScanlineIterator` cast directly via `static_cast<OutputPixelType>(inputIt.Get())` and never reference `InputPixelType` inside the function body — the typedef is dead.

The two other copy variants in the same file legitimately use both:

- Method 3 (line 187): `*outputIt = OutputPixelType(InputPixelType(*inputIt));`
- Method 4 (line 208): `for (const InputPixelType & inputPixel : itk::ImageRegionRange<const TInputImage>(...))`

Left unchanged.

</details>

<!--
provenance: claude-code session 2026-04-23
trigger: user reported -Wunused-local-typedefs warnings at lines 119 and 142 from GHA CI runner
introduced_by: 7fb08c12def (Bradley Lowekamp, 2025-12-10)
sites_fixed: CopyRegionIterator (line 119), CopyScanlineIterator (line 142)
sites_intentionally_left: Method 3 at line 187 (uses InputPixelType), Method 4 at line 208 (uses InputPixelType)
-->