### PR TITLE
COMP: Remove unused InputPixelType aliases in CopyIterationBenchmark

### DIFF
--- a/examples/Core/itkCopyIterationBenchmark.cxx
+++ b/examples/Core/itkCopyIterationBenchmark.cxx
@@ -116,7 +116,6 @@ template <typename TInputImage, typename TOutputImage>
 void
 CopyRegionIterator(const TInputImage * inputPtr, TOutputImage * outputPtr)
 {
-  using InputPixelType = typename TInputImage::PixelType;
   using OutputPixelType = typename TOutputImage::PixelType;
   using ImageRegionConstIterator = itk::ImageRegionConstIterator<TInputImage>;
   using ImageRegionIterator = itk::ImageRegionIterator<TOutputImage>;
@@ -139,7 +138,6 @@ template <typename TInputImage, typename TOutputImage>
 void
 CopyScanlineIterator(const TInputImage * inputPtr, TOutputImage * outputPtr)
 {
-  using InputPixelType = typename TInputImage::PixelType;
   using OutputPixelType = typename TOutputImage::PixelType;
   using ImageScanlineConstIterator = itk::ImageScanlineConstIterator<TInputImage>;
   using ImageScanlineIterator = itk::ImageScanlineIterator<TOutputImage>;


### PR DESCRIPTION
Remove two unused \`using InputPixelType = typename TInputImage::PixelType;\` declarations in \`CopyRegionIterator\` and \`CopyScanlineIterator\`. The other benchmark methods still use the alias and are unchanged.

<details>
<summary>Warning being fixed</summary>

\`\`\`
itkCopyIterationBenchmark.cxx:78:9: warning: unused type alias 'InputPixelType' [-Wunused-local-typedef]
itkCopyIterationBenchmark.cxx:101:9: warning: unused type alias 'InputPixelType' [-Wunused-local-typedef]
\`\`\`
(line numbers from the ITK Remote-Modules build tree; direct sources are lines 119 and 142.)
</details>

<!--
provenance: claude-code session 2026-04-24
related_files: examples/Core/itkCopyIterationBenchmark.cxx:119,142
-->