### PR TITLE
ENH: Add ITKTestingData gh-pages URL as primary CID source

### DIFF
--- a/examples/CMake/ITKBenchmarksExternalData.cmake
+++ b/examples/CMake/ITKBenchmarksExternalData.cmake
@@ -25,6 +25,11 @@ set(ExternalData_URL_TEMPLATES "" CACHE STRING
 file:///var/bigharddrive/%(algo)/%(hash)")
 mark_as_advanced(ExternalData_URL_TEMPLATES)
 list(APPEND ExternalData_URL_TEMPLATES
+  # Primary CID source: ITKTestingData gh-pages mirror.
+  # %(algo) substitutes the uppercase algorithm name (CID, MD5, SHA512),
+  # matching the case-sensitive directory layout on the gh-pages branch.
+  "https://insightsoftwareconsortium.github.io/ITKTestingData/%(algo)/%(hash)"
+
   # Data published on MIDAS
   "https://midas3.kitware.com/midas/api/rest?method=midas.bitstream.download&checksum=%(hash)&algorithm=%(algo)"
 


### PR DESCRIPTION
Add the `ITKTestingData` gh-pages mirror at the head of the local `ExternalData_URL_TEMPLATES` list in `examples/CMake/ITKBenchmarksExternalData.cmake`.

Previously the list contained only the legacy MIDAS endpoint (midas3.kitware.com), itk.org, and the slicer.kitware.com mirror — none of which serve CID-keyed blobs. Putting gh-pages first matches the convention used by the inherited `ITKExternalData.cmake` and parallels commit 317ab5fdaed2 on the ITK side.

<!-- claude-code 2026-04-29 phase3-ghpages-url -->
